### PR TITLE
deploy CI: Update to actions/github-script@v7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Dispatch deploy workflow
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_PAT }}
           script: |


### PR DESCRIPTION
Node.js 20への更新対応

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/github-script@v6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.